### PR TITLE
Return CMS and not cms for menu items

### DIFF
--- a/proxy/src/index.ts
+++ b/proxy/src/index.ts
@@ -37,7 +37,7 @@ app.get('/content/:owner/:repository/:branch/:path{.*}?', async (ctx) => {
   })
 })
 
-// URLs like: http://localhost:9000/menu/nordcraftengine/documentation/main/the-editor/canvas
+// URLs like: http://localhost:9000/menu/nordcraftengine/documentation/main
 app.get('/menu/:owner/:repository/:branch', async (ctx) => {
   const owner = ctx.req.param('owner')
   const repository = ctx.req.param('repository')

--- a/proxy/src/routes/fetchMenu.ts
+++ b/proxy/src/routes/fetchMenu.ts
@@ -2,7 +2,7 @@ import type { FetchMenu, MenuItem } from '../types'
 import { errorResponse, fetchMenuItems, json, preferLocalData } from '../utils'
 import { loadJsonFile } from '../utils/jsonLoader'
 
-// URLs like: http://localhost:8989/content/nordcraftengine/documentation/main/the-editor/canvas
+// URLs like: http://localhost:9000/menu/nordcraftengine/documentation/main
 export const fetchMenu = async ({
   params: { owner, repository, branch },
 }: FetchMenu) => {

--- a/proxy/src/utils/helpers.ts
+++ b/proxy/src/utils/helpers.ts
@@ -9,7 +9,9 @@ export const getFilename = (fileName: string) => {
 export const getNameFromFilename = (fileName: string) => {
   const fileNameWithoutExtension = fileName.split('.')[0]
   const lowerCase = toLower(startCase(getFilename(fileNameWithoutExtension)))
-  return upperFirst(lowerCase).replaceAll('nordcraft', 'Nordcraft')
+  return upperFirst(lowerCase)
+    .replaceAll('nordcraft', 'Nordcraft')
+    .replaceAll('cms', 'CMS')
 }
 
 export const getSlugFromFilename = (fileName: string) => {


### PR DESCRIPTION
# Documentation Pull Request

This PR is a bandaid to show 'cms' as `CMS' in menu items, as to unblock https://github.com/nordcraftengine/documentation/pull/304

A more thorough solution is needed for formatting menu items in due course.

Fixes https://github.com/nordcraftengine/documentation/issues/334

