### PR TITLE
Fix image titles, do not just take first word

### DIFF
--- a/proxy/src/utils/fetchPageData.ts
+++ b/proxy/src/utils/fetchPageData.ts
@@ -75,9 +75,13 @@ const getProcessedTokens = (tokens: any[]) => {
     }
 
     if (token.type === 'image' || token.type === 'image-static') {
-      const parts = token.href.split(' ')
-      processedToken.href = parts[0]
-      processedToken.title = parts[1].replaceAll("'", '')
+      const firstSpaceIndex = token.href.indexOf(' ')
+      if (firstSpaceIndex !== -1) {
+        processedToken.href = token.href.substring(0, firstSpaceIndex)
+        processedToken.title = token.href
+          .substring(firstSpaceIndex + 1)
+          .replaceAll("'", '')
+      }
     }
 
     if (token.tokens) {


### PR DESCRIPTION
# Documentation Pull Request

## Description

The previous change to the proxy just got the first word of the image title. Now it gets the rest of the string 😅