### PR TITLE
Fix contributors retrieval, given emails is now an array

### DIFF
--- a/proxy/bin/buildContributors.ts
+++ b/proxy/bin/buildContributors.ts
@@ -31,11 +31,12 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 const contributorMapFile = fs.readFileSync('./contributors.json', 'utf-8')
 const contributorMap = (
   JSON.parse(contributorMapFile) as Array<{
-    email: string
+    email: string[]
     username: string
     ignored?: boolean
   }>
 ).filter((contributor) => !contributor.ignored)
+
 const getGitHubUser = async (username: string) => {
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github+json',

--- a/proxy/bin/fetchContributors.ts
+++ b/proxy/bin/fetchContributors.ts
@@ -16,7 +16,11 @@ export const fetchContributors = async ({
   allContributors,
   path,
 }: {
-  allContributors: Array<{ email: string; username: string; avatar?: string }>
+  allContributors: Array<{
+    email: string[]
+    username: string
+    avatar?: string
+  }>
   path: string
 }) => {
   const { stdout: rawContributors } = await execPromise(
@@ -34,12 +38,13 @@ export const fetchContributors = async ({
     })
     .filter((c) => typeof c.email === 'string' && c.email.length > 0)
     .sort((a, b) => b.count - a.count)
+
   const { stdout: lastEditedAt } = await execPromise(
     // Get the last edited date of the file in ISO format
     `git log -1 --format="%ad" --date=iso ../${path}`,
   )
   const matchContributor = (email: string) => {
-    return allContributors.find((c) => c.email === email)
+    return allContributors.find((c) => c.email.includes(email))
   }
   return {
     contributors: fileContributors


### PR DESCRIPTION
We recently changed the contributors email to an array to account for github generated emails. This PR now returns contributors correctly.