### PR TITLE
Update editorUrl to linkUrl so it is more obvious we can use links to both the editor and live sites

### DIFF
--- a/docs/21-guides/99-contribution/index.md
+++ b/docs/21-guides/99-contribution/index.md
@@ -150,12 +150,13 @@ For project examples, use the following format:
 @@@ project-example
 title: A cool project
 description: A cool description in one sentence.
-editorUrl: https://editor.nordcraft.com/projects/docs_examples/branches/main
+linkUrl: https://editor.nordcraft.com/projects/docs_examples/branches/main
 imageUrl: image.webp
 imageAltText: Descriptive text to describe the image
 @@@
 
-Place the image in the same folder as the page's `index.md` file.
+- Place the image in the same folder as the page's `index.md` file.
+- The `linkUrl` can point to the project in the Nordcraft editor or a live site in production.
 
 ### Component examples
 

--- a/proxy/src/markdown-extensions/project-example.ts
+++ b/proxy/src/markdown-extensions/project-example.ts
@@ -4,7 +4,7 @@ export type ProjectExampleToken = {
   type: 'project-example'
   title: string
   description: string
-  editorUrl: string
+  linkUrl: string
   imageUrl: string
   imageAltText: string
   raw: string
@@ -25,7 +25,7 @@ export const projectExampleExtension: TokenizerAndRendererExtension = {
       // Parse parameters from the content
       const titleMatch = content.match(/title:\s*([^\n]+)/)
       const descriptionMatch = content.match(/description:\s*([^\n]+)/)
-      const editorUrlMatch = content.match(/editorUrl:\s*([^\n]+)/)
+      const linkUrlMatch = content.match(/linkUrl:\s*([^\n]+)/)
       const imageUrlMatch = content.match(/imageUrl:\s*([^\n]+)/)
       const imageAltTextMatch = content.match(/imageAltText:\s*([^\n]+)/)
 
@@ -33,7 +33,7 @@ export const projectExampleExtension: TokenizerAndRendererExtension = {
         type: 'project-example',
         title: titleMatch ? titleMatch[1].trim() : '',
         description: descriptionMatch ? descriptionMatch[1].trim() : '',
-        editorUrl: editorUrlMatch ? editorUrlMatch[1].trim() : '',
+        linkUrl: linkUrlMatch ? linkUrlMatch[1].trim() : '',
         imageUrl: imageUrlMatch ? imageUrlMatch[1].trim() : '',
         imageAltText: imageAltTextMatch ? imageAltTextMatch[1].trim() : '',
         raw: fullMatch,


### PR DESCRIPTION
Turns out we don't yet have enough examples to link to the editor so this change makes it obvious we can use links to both the editor and live production sites for the project examples.