### PR TITLE
Changed parse as image to blob

### DIFF
--- a/docs/connecting-data/advanced-api-features/index.md
+++ b/docs/connecting-data/advanced-api-features/index.md
@@ -119,7 +119,7 @@ The **Parse as** dropdown allows you to select from several parsing options:
 - **JSON**: Parses the response as a JSON object
 - **Event stream**: Parses as server-sent events (SSE)
 - **JSON stream**: Parses as a stream of JSON objects (see the [NDJSON](https://github.com/ndjson/ndjson-spec) specification)
-- **Image**: Handles the response as an image
+- **Blob**: Handles the response as a blob (read more about blobs on the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blob))
 
 This is particularly useful when working with APIs that return incorrect or missing `Content-Type` headers.
 


### PR DESCRIPTION
# Documentation Pull Request

## Description

This PR changes the wording of the advanced API feature "Response parsing" from "Image" to "Blob" to better reflect what that option actually does.

## Type of change

<!-- Please check the options that are relevant by changing [ ] to [x] -->

- [x] Documentation update (typo fixes, improved clarity, etc.)
- [ ] New documentation (entirely new pages or sections)
- [ ] Documentation restructuring (reorganizing content)
- [ ] Example updates (new or improved examples)
- [ ] Image updates (new or improved images)
- [ ] Other (please describe):

## Checklist

<!-- Before submitting your PR, please confirm that: -->

- [x] My changes follow the formatting guidelines in the contribution guide
- [x] I have performed a self-review of my changes
- [x] I have tested all links to ensure they point to valid pages
- [x] I have verified that images display correctly
- [ ] I have checked examples (if applicable) to ensure they work correctly
- [x] I have used consistent terminology throughout the documentation
- [ ] I have placed content in the correct numbered folders to maintain proper ordering
- [x] I have checked my changes for spelling and grammatical errors

## Additional context

This change is already reflected in the editor
